### PR TITLE
Selection customization, and hover style modification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ types
 .size-snapshot.json
 *.tgz
 **/*.tgz
+lib

--- a/README.md
+++ b/README.md
@@ -104,31 +104,37 @@ can be used to customise the UX of your _React Tree_ component. You can explore 
   loadingString={string}
   emptyItemsString={string}
   containerStyle={CSSProperties}
+  toggleSelect={boolean}
+  multiSelect={boolean}
+  unselectOnClickOutside={boolean}
 />
 ```
 
 ### Props list
 
-| Prop name          | Prop type                                                                                           | Default | Required | Description                                                                   |
-| ------------------ | --------------------------------------------------------------------------------------------------- | ------- | -------- | ----------------------------------------------------------------------------- |
-| `nodes`            | `Node[]`                                                                                            | `[]`    | Y        | The data set for react tree to render                                         |
-| `onSelect`         | `(nodeIds: string[]) => void`                                                                       | `null`  | N        | Event listener called on every select/deselect action                         |
-| `onOpenClose`      | `(nodeIds: string[]) => void`                                                                       | `null`  | N        | Event listener called on every open/close action                              |
-| `theme`            | `string`                                                                                            | `dark`  | N        | The currently selected theme                                                  |
-| `customTheme`      | `[key:string] : ReactTreeTheme`                                                                     | `null`  | N        | Specify a custom theme                                                        |
-| `size`             | `full`, `half`, `narrow`                                                                            | `full`  | N        | Specify a pre-defined size                                                    |
-| `grow`             | `boolean`                                                                                           | `false` | N        | Whether or not the tree will attempt to fill its container                    |
-| `showEmptyItems`   | `boolean`                                                                                           | `false` | N        | Whether or not to display an indicator for empty folders                      |
-| `isLoading`        | `boolean`                                                                                           | `false` | N        | Display a loader instead of the rendered tree                                 |
-| `noIcons`          | `boolean`                                                                                           | `false` | N        | Disable the icon display                                                      |
-| `containerStyle`   | `CSSProperties`                                                                                     | `null`  | N        | Style the _React Tree_ container                                              |
-| `NodeRenderer`     | `({ data: Node; isOpen: boolean; isRoot: boolean; selected: boolean; level: number }) => ReactNode` | `null`  | N        | A custom renderer for `Node` elements                                         |
-| `LeafRenderer`     | `({ data: Node; selected: boolean; level: number }) => ReactNode`                                   | `null`  | N        | A custom renderer for `Leaf` elements                                         |
-| `IconRenderer`     | `({ type: 'node' \| 'leaf' \| 'loader', data: Node }) => ReactElement`                                                               | `null`  | N        | A custom renderer for `Icon` elements                                         |
-| `animations`       | `boolean`                                                                                           | `false` | N        | Enable animated micro-interactions                                            |
-| `noDataString`     | `string`                                                                                            | `null`  | N        | Replace the default message shown when there is no data to render             |
-| `loadingString`    | `string`                                                                                            | `null`  | N        | Replace the default message shown when `isLoading` is active                  |
-| `emptyItemsString` | `string`                                                                                            | `null`  | N        | Replace the default message shown when the `showEmptyItems` setting is active |
+| Prop name                | Prop type                                                                                           | Default | Required | Description                                                                   |
+| ------------------------ | --------------------------------------------------------------------------------------------------- | ------- | -------- | ----------------------------------------------------------------------------- |
+| `nodes`                  | `Node[]`                                                                                            | `[]`    | Y        | The data set for react tree to render                                         |
+| `onSelect`               | `(nodeIds: string[]) => void`                                                                       | `null`  | N        | Event listener called on every select/deselect action                         |
+| `onOpenClose`            | `(nodeIds: string[]) => void`                                                                       | `null`  | N        | Event listener called on every open/close action                              |
+| `theme`                  | `string`                                                                                            | `dark`  | N        | The currently selected theme                                                  |
+| `customTheme`            | `[key:string] : ReactTreeTheme`                                                                     | `null`  | N        | Specify a custom theme                                                        |
+| `size`                   | `full`, `half`, `narrow`                                                                            | `full`  | N        | Specify a pre-defined size                                                    |
+| `grow`                   | `boolean`                                                                                           | `false` | N        | Whether or not the tree will attempt to fill its container                    |
+| `showEmptyItems`         | `boolean`                                                                                           | `false` | N        | Whether or not to display an indicator for empty folders                      |
+| `isLoading`              | `boolean`                                                                                           | `false` | N        | Display a loader instead of the rendered tree                                 |
+| `noIcons`                | `boolean`                                                                                           | `false` | N        | Disable the icon display                                                      |
+| `containerStyle`         | `CSSProperties`                                                                                     | `null`  | N        | Style the _React Tree_ container                                              |
+| `NodeRenderer`           | `({ data: Node; isOpen: boolean; isRoot: boolean; selected: boolean; level: number }) => ReactNode` | `null`  | N        | A custom renderer for `Node` elements                                         |
+| `LeafRenderer`           | `({ data: Node; selected: boolean; level: number }) => ReactNode`                                   | `null`  | N        | A custom renderer for `Leaf` elements                                         |
+| `IconRenderer`           | `({ type: 'node' \| 'leaf' \| 'loader', data: Node }) => ReactElement`                              | `null`  | N        | A custom renderer for `Icon` elements                                         |
+| `animations`             | `boolean`                                                                                           | `false` | N        | Enable animated micro-interactions                                            |
+| `noDataString`           | `string`                                                                                            | `null`  | N        | Replace the default message shown when there is no data to render             |
+| `loadingString`          | `string`                                                                                            | `null`  | N        | Replace the default message shown when `isLoading` is active                  |
+| `emptyItemsString`       | `string`                                                                                            | `null`  | N        | Replace the default message shown when the `showEmptyItems` setting is active |
+| `toggleSelect`           | `boolean`                                                                                           | `true`  | N        | Whether or not clicking on already-selected items will unselect them          |
+| `multiSelect`            | `boolean`                                                                                           | `true`  | N        | Whether or not more than one item can be selected using `meta` or `ctrl` key  |
+| `unselectOnClickOutside` | `boolean`                                                                                           | `true`  | N        | Whether or not clicking outside the treeview should clear the selection       |
 
 ## Typescript
 
@@ -226,7 +232,7 @@ If you want to customize the icons, you can! Some conditions:
 
 You can customize the icons by providing a render function to the props `IconRenderer` which _must_ return a _valid react element/component_. The icon renderer will be passed two props:
 
-- `type : 'node' | 'leaf' | 'loader'`:  use to conditionally render the correct icon.
+- `type : 'node' | 'leaf' | 'loader'`: use to conditionally render the correct icon.
 - `data: Node`: the content of the node/leaf
 
 ```jsx

--- a/src/Tree.ts
+++ b/src/Tree.ts
@@ -57,6 +57,9 @@ export declare interface TreeProps {
   noDataString?: string
   loadingString?: string
   emptyItemsString?: string | null
+  multiSelect?: boolean
+  toggleSelect?: boolean
+  unselectOnOutsideClick: boolean
 }
 
 declare function ToggleFunction(nodeId: NodeId, multi: boolean): void

--- a/src/Tree.ts
+++ b/src/Tree.ts
@@ -26,6 +26,7 @@ export declare type LeafList = Leaf[]
 export declare type Node = Entry &
   Leaf & {
     items?: LeafList
+    selectable?: boolean
   }
 
 /**
@@ -95,6 +96,7 @@ export declare type ContainerProps = Partial<TreeProps> & {
   openNodes: Array<NodeId>
   didToggleSelect: GenericStateToggler
   didToggleOpen: GenericStateToggler
+  selectable?: boolean
 }
 
 export declare type ElementProps = Partial<ContainerProps> & {

--- a/src/Tree.ts
+++ b/src/Tree.ts
@@ -13,7 +13,7 @@ export declare interface Entry {
 /**
  * @public
  */
-export declare type Leaf = Entry & { label: string }
+export declare type Leaf = Entry & { label: string; tooltip?: string }
 
 /**
  * @public

--- a/src/Tree/Container.tsx
+++ b/src/Tree/Container.tsx
@@ -79,6 +79,7 @@ const Container: React.FC<ContainerProps> = ({
                   NodeRenderer={NodeRenderer}
                   IconRenderer={IconRenderer}
                   borderTop={(!parent && k !== 0) || !!parent}
+                  selectable={item.selectable}
                 />
                 {openNodes.includes(item.id) && (
                   <Children>

--- a/src/Tree/Elements.tsx
+++ b/src/Tree/Elements.tsx
@@ -6,10 +6,6 @@ export const Element = styled(m.div)<{ currentTheme: string; borderTop: boolean;
   min-height: 20px;
   min-width: 0;
   transition: all 0.2s ease-in-out;
-  &:hover {
-    background: ${(props) => props.theme._themes[props.currentTheme || 'dark'].hoverBg};
-    color: ${(props) => props.theme._themes[props.currentTheme || 'dark'].hoverText};
-  }
 
   ${({ theme, currentTheme, borderTop }) => (borderTop ? `border-top: 1px solid ${theme._themes[currentTheme || 'dark'].separator};` : '')}
 
@@ -19,7 +15,12 @@ export const Element = styled(m.div)<{ currentTheme: string; borderTop: boolean;
     background-color: ${props.theme._themes[props.currentTheme || 'dark'].selectedBg};
     color: ${props.theme._themes[props.currentTheme || 'dark'].selectedText};
   `
-      : ''}
+      : `
+    &:hover {
+      background: ${props.theme._themes[props.currentTheme || 'dark'].hoverBg};
+      color: ${props.theme._themes[props.currentTheme || 'dark'].hoverText};
+    }
+  `}
 `
 
 export const Empty = styled(Element)<{ currentTheme: string }>`

--- a/src/Tree/LeafElement.tsx
+++ b/src/Tree/LeafElement.tsx
@@ -51,13 +51,13 @@ const LeafElement = React.forwardRef<HTMLDivElement, ElementProps>(
 
     const content =
       typeof LeafRenderer === 'function' ? (
-        <div title={data.label} ref={ref} data-node-id={data.id} onClick={(e) => handleClick(e, data.id)}>
+        <div title={data.tooltip || data.label} ref={ref} data-node-id={data.id} onClick={(e) => handleClick(e, data.id)}>
           {LeafRenderer({ data, selected, level })}
         </div>
       ) : (
         <div ref={ref}>
           <Element
-            title={data.label}
+            title={data.tooltip || data.label}
             borderTop={borderTop}
             data-node-id={data.id}
             selected={selected}

--- a/src/Tree/NodeElement.tsx
+++ b/src/Tree/NodeElement.tsx
@@ -65,7 +65,7 @@ const NodeElement = React.forwardRef<HTMLDivElement, ElementProps>(
 
     const content =
       typeof NodeRenderer === 'function' ? (
-        <div title={data.label} ref={ref} data-node-id={data.id} onClick={(e) => handleClick(e, data.id)}>
+        <div title={data.tooltip || data.label} ref={ref} data-node-id={data.id} onClick={(e) => handleClick(e, data.id)}>
           {NodeRenderer({ data, isOpen, isRoot, selected, level })}
         </div>
       ) : (
@@ -77,7 +77,7 @@ const NodeElement = React.forwardRef<HTMLDivElement, ElementProps>(
             selected={selected}
             onClick={(e) => handleClick(e, data.id)}
             borderTop={borderTop}
-            title={data.label}
+            title={data.tooltip || data.label}
           >
             <Wrapper level={level}>
               {!noIcons && <span style={{ paddingRight: '8px' }}>{renderedIcon}</span>}

--- a/src/Tree/NodeElement.tsx
+++ b/src/Tree/NodeElement.tsx
@@ -29,7 +29,8 @@ const NodeElement = React.forwardRef<HTMLDivElement, ElementProps>(
       didToggleSelect = () => {},
       NodeRenderer = null,
       IconRenderer = null,
-      borderTop = false
+      borderTop = false,
+      selectable = true
     },
     ref
   ) => {
@@ -41,8 +42,9 @@ const NodeElement = React.forwardRef<HTMLDivElement, ElementProps>(
 
     const handleClick = React.useCallback(
       (e: React.MouseEvent, nodeId: NodeId) => {
-        didToggleSelect(nodeId, e.metaKey || e.ctrlKey)
-        if (!e.metaKey && !e.ctrlKey) {
+        const multi = e.metaKey || e.ctrlKey
+        if (selectable) didToggleSelect(nodeId, multi)
+        if (!multi) {
           didToggleOpen(nodeId, true)
         }
       },


### PR DESCRIPTION
Thanks for making this!

Some changes for your consideration:

I've added some additional props to configure selection behaviour ... they all have the original default value of true:
- toggleSelect defines whether clicking an already-selected item will unselect it
- multiSelect defines whether multiselect is allowed
- unselectOnOutsideClick defines whether the selection is cleared if you click outside the control

I've also added a "selectable" flag to Node, defining whether it can be selected (default=true).

Finally, I've modified the style so that the hover style does not take precedence over the selected item style.

Thanks again!