### PR TITLE
Four modifications (sorry, should've made four PRs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,8 @@
 dist
 js
 node_modules
-types
+/types
 .size-snapshot.json
 *.tgz
 **/*.tgz
-lib
+/lib

--- a/.npmignore
+++ b/.npmignore
@@ -14,3 +14,4 @@ rollup.config.js
 tsconfig.build.json
 tsconfig.json
 yarn.lock
+buildWindows.bat

--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ can be used to customise the UX of your _React Tree_ component. You can explore 
 | `NodeRenderer`           | `({ data: Node; isOpen: boolean; isRoot: boolean; selected: boolean; level: number }) => ReactNode` | `null`  | N        | A custom renderer for `Node` elements                                         |
 | `LeafRenderer`           | `({ data: Node; selected: boolean; level: number }) => ReactNode`                                   | `null`  | N        | A custom renderer for `Leaf` elements                                         |
 | `IconRenderer`           | `({ type: 'node' \| 'leaf' \| 'loader', data: Node }) => ReactElement`                              | `null`  | N        | A custom renderer for `Icon` elements                                         |
-| `animations`             | `boolean`                                                                                           | `false` | N        | Enable animated micro-interactions                                            |
+| `animateDropdown`        | `boolean`                                                                                           | `false` | N        | Enable animated "cascade" of dropdown lists (was `animations`)                |
+| `animateSelection`       | `boolean`                                                                                           | `true`  | N        | Enable animated selections (leaf selection bg, and node icon rotate)          |
 | `noDataString`           | `string`                                                                                            | `null`  | N        | Replace the default message shown when there is no data to render             |
 | `loadingString`          | `string`                                                                                            | `null`  | N        | Replace the default message shown when `isLoading` is active                  |
 | `emptyItemsString`       | `string`                                                                                            | `null`  | N        | Replace the default message shown when the `showEmptyItems` setting is active |
@@ -230,7 +231,9 @@ If you want to customize the icons, you can! Some conditions:
 - the icons are set to a default square dimensions and will force whatever icons you provide into a `20px` square container using the `object-fit: contain` method
 - overflow out of the box is hidden
 
-You can customize the icons by providing a render function to the props `IconRenderer` which _must_ return a _valid react element/component_. The icon renderer will be passed two props:
+You can customize the icons by providing a render function to the props `IconRenderer` which _must_ return a _valid react element/component_ or `null`.
+
+The icon renderer will be passed two props:
 
 - `type : 'node' | 'leaf' | 'loader'`: use to conditionally render the correct icon.
 - `data: Node`: the content of the node/leaf
@@ -240,6 +243,8 @@ IconRender={({type}) => {
   return type === 'leaf | node' ? <...> : ...
 }}
 ```
+
+If `null` is returned by the rendering function, the appropriate default icon will be used instead.
 
 ## TODO in v3 and beyond
 

--- a/buildWindows.bat
+++ b/buildWindows.bat
@@ -1,0 +1,11 @@
+@echo off
+REM This has to be in a separate batch file rather than a sequence of ... && ... commands, because the
+REM "set" command only takes effect AFTER the line containing it has completed. Chaining it with &&
+REM means it will NOT take effect for the commands following it in the same line.
+set NODE_ENV=production
+IF EXIST .\\js ( rmdir /S /Q .\\js )
+REM "tsc" and "yarn" are batch files, so unless we use "call" to execute them, execution won't come back here.
+call tsc -p tsconfig.build.json
+call yarn copy-files-windows
+REM I don't know if "rollup" is a batch file, but it doesn't matter either way.
+rollup -c

--- a/package.json
+++ b/package.json
@@ -72,9 +72,11 @@
   "scripts": {
     "test": "jest",
     "build": "NODE_ENV=production rm -rf ./js && tsc -p tsconfig.build.json && yarn copy-files && rollup -c",
+    "build-windows": "call buildWindows.bat",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook -o docs",
-    "copy-files": "cp ./src/assets/images/*.svg ./js/assets/images"
+    "copy-files": "cp ./src/assets/images/*.svg ./js/assets/images",
+    "copy-files-windows": "copy .\\src\\assets\\images\\*.svg .\\js\\assets\\images"
   },
   "keywords": [
     "react",

--- a/src/Tree.ts
+++ b/src/Tree.ts
@@ -53,7 +53,7 @@ export declare interface TreeProps {
     | (({ data, isOpen, isRoot, selected, level }: { data: Node; isOpen: boolean; isRoot: boolean; selected: boolean; level: number }) => ReactNode)
     | null
   LeafRenderer?: (({ data, selected, level }: { data: Node; selected: boolean; level: number }) => ReactNode) | null
-  IconRenderer?: (({ data, type }: { data?: Node; type?: 'leaf' | 'node' | 'loader' }) => ReactElement) | null
+  IconRenderer?: (({ data, type }: { data?: Node; type?: 'leaf' | 'node' | 'loader' }) => ReactElement | null) | null
   animations?: boolean
   noDataString?: string
   loadingString?: string
@@ -61,6 +61,8 @@ export declare interface TreeProps {
   multiSelect?: boolean
   toggleSelect?: boolean
   unselectOnOutsideClick: boolean
+  animateSelection?: boolean
+  animateDropdown?: boolean
 }
 
 declare function ToggleFunction(nodeId: NodeId, multi: boolean): void

--- a/src/Tree/Container.tsx
+++ b/src/Tree/Container.tsx
@@ -1,12 +1,12 @@
+import { m } from 'framer-motion'
 import * as React from 'react'
 import styled from 'styled-components'
-import { m } from 'framer-motion'
-import NodeElement from './NodeElement'
-import LeafElement from './LeafElement'
+import { getAllDescendantsForCurrentContainers, getChildrenByParent } from '../lib/NodeList'
+import type { ContainerProps, Node, NodeList } from '../Tree'
 import { Empty } from './Elements'
+import LeafElement from './LeafElement'
+import NodeElement from './NodeElement'
 import Wrapper from './Wrapper'
-import { getChildrenByParent, getAllDescendantsForCurrentContainers } from '../lib/NodeList'
-import type { ContainerProps, NodeList, Node } from '../Tree'
 
 const ContainerWrapper = styled(m.div)`
   min-width: 0;
@@ -39,7 +39,8 @@ const Container: React.FC<ContainerProps> = ({
   NodeRenderer = null,
   LeafRenderer = null,
   IconRenderer = null,
-  animations = false,
+  animateDropdown = false,
+  animateSelection = true,
   emptyItemsString = null
 }) => {
   // get container items for this level and ancestors for next container
@@ -51,7 +52,7 @@ const Container: React.FC<ContainerProps> = ({
     return getAllDescendantsForCurrentContainers(nodes || [], containerItems)
   }, [containerItems])
 
-  const animationsSpec = animations
+  const animationsSpec = animateDropdown
     ? {
         initial: { opacity: 0, y: -25 },
         animate: { opacity: 1, y: 0 },
@@ -80,6 +81,7 @@ const Container: React.FC<ContainerProps> = ({
                   IconRenderer={IconRenderer}
                   borderTop={(!parent && k !== 0) || !!parent}
                   selectable={item.selectable}
+                  animateSelection={animateSelection}
                 />
                 {openNodes.includes(item.id) && (
                   <Children>
@@ -97,7 +99,8 @@ const Container: React.FC<ContainerProps> = ({
                       NodeRenderer={NodeRenderer}
                       LeafRenderer={LeafRenderer}
                       IconRenderer={IconRenderer}
-                      animations={animations}
+                      animateDropdown={animateDropdown}
+                      animateSelection={animateSelection}
                       emptyItemsString={emptyItemsString}
                     />
                     {item.items &&
@@ -115,6 +118,7 @@ const Container: React.FC<ContainerProps> = ({
                             LeafRenderer={LeafRenderer}
                             IconRenderer={IconRenderer}
                             didToggleSelect={didToggleSelect}
+                            animateSelection={animateSelection}
                             borderTop
                           />
                         )

--- a/src/Tree/Elements.tsx
+++ b/src/Tree/Elements.tsx
@@ -1,11 +1,11 @@
-import styled from 'styled-components'
 import { m } from 'framer-motion'
+import styled from 'styled-components'
 
-export const Element = styled(m.div)<{ currentTheme: string; borderTop: boolean; selected: boolean }>`
+export const Element = styled(m.div)<{ currentTheme: string; borderTop: boolean; selected: boolean; animateSelection?: boolean }>`
   padding: 8px 15px 8px 4px;
   min-height: 20px;
   min-width: 0;
-  transition: all 0.2s ease-in-out;
+  ${({ animateSelection }) => (animateSelection ? 'transition: all 0.2s ease-in-out;' : '')}
 
   ${({ theme, currentTheme, borderTop }) => (borderTop ? `border-top: 1px solid ${theme._themes[currentTheme || 'dark'].separator};` : '')}
 

--- a/src/Tree/Icon.tsx
+++ b/src/Tree/Icon.tsx
@@ -1,6 +1,6 @@
 // @flow
-import * as React from 'react'
 import { m } from 'framer-motion'
+import * as React from 'react'
 import styled from 'styled-components'
 
 interface ReactTreeIcon {
@@ -8,6 +8,7 @@ interface ReactTreeIcon {
   currentTheme?: string
   defaultIcon?: boolean
   children?: React.ReactNode
+  rotate?: number
 }
 
 interface ISizes {
@@ -22,7 +23,7 @@ const sizes: ISizes = {
   xsmall: '10px'
 }
 
-const IconWrapper = styled(m.div)<{ size: string }>`
+const IconWrapper = styled(m.div)<{ size: string; rotate?: number }>`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -36,13 +37,15 @@ const IconWrapper = styled(m.div)<{ size: string }>`
     width: 100%;
     height: 100%;
     object-fit: contain;
+    ${({ rotate }) => (rotate ? `transform: rotate(${rotate}deg);` : '')}
   }
 `
 
-const ReactTreeIconContainer = styled(IconWrapper)<{ currentTheme: string }>`
+const ReactTreeIconContainer = styled(IconWrapper)<{ currentTheme: string; rotate?: number }>`
   svg {
     height: 100%;
     width: 100%;
+    ${({ rotate }) => (rotate ? `transform: rotate(${rotate}deg);` : '')}
 
     * {
       fill: ${({ theme, currentTheme }) => `${theme._themes[currentTheme || 'dark'].icon}`};
@@ -51,13 +54,13 @@ const ReactTreeIconContainer = styled(IconWrapper)<{ currentTheme: string }>`
   }
 `
 
-const Icon = React.forwardRef<HTMLDivElement, ReactTreeIcon>(({ size = 'default', currentTheme = 'dark', defaultIcon = false, children }, ref) => {
+const Icon = React.forwardRef<HTMLDivElement, ReactTreeIcon>(({ size = 'default', currentTheme = 'dark', defaultIcon = false, children, rotate }, ref) => {
   return defaultIcon ? (
-    <ReactTreeIconContainer ref={ref} currentTheme={currentTheme} size={size}>
+    <ReactTreeIconContainer ref={ref} currentTheme={currentTheme} size={size} rotate={rotate}>
       {children}
     </ReactTreeIconContainer>
   ) : (
-    <IconWrapper ref={ref} size={size}>
+    <IconWrapper ref={ref} size={size} rotate={rotate}>
       {children}
     </IconWrapper>
   )

--- a/src/Tree/LeafElement.tsx
+++ b/src/Tree/LeafElement.tsx
@@ -1,12 +1,12 @@
+import { m } from 'framer-motion'
 import * as React from 'react'
 import { useTheme } from 'styled-components'
-import { m } from 'framer-motion'
-import Wrapper from './Wrapper'
-import { NodeText } from './Text'
-import { Element } from './Elements'
-import Icon from './Icon'
 import Icons from '../assets/images/Icons'
 import { ElementProps, NodeId } from '../Tree'
+import { Element } from './Elements'
+import Icon from './Icon'
+import { NodeText } from './Text'
+import Wrapper from './Wrapper'
 
 const DefaultIcon = Icons['file']
 
@@ -21,7 +21,8 @@ const LeafElement = React.forwardRef<HTMLDivElement, ElementProps>(
       didToggleSelect = () => {},
       LeafRenderer = null,
       IconRenderer = null,
-      borderTop = false
+      borderTop = false,
+      animateSelection = true
     },
     ref
   ) => {
@@ -38,16 +39,16 @@ const LeafElement = React.forwardRef<HTMLDivElement, ElementProps>(
       [data, didToggleSelect]
     )
 
-    const renderedIcon =
-      IconRenderer && typeof IconRenderer === 'function' ? (
-        <Icon size="large" currentTheme={currentTheme}>
-          <IconRenderer data={data} type="leaf" />
-        </Icon>
-      ) : (
-        <Icon size={theme._themes[currentTheme || 'dark'].textSize} defaultIcon currentTheme={currentTheme}>
-          <DefaultIcon />
-        </Icon>
-      )
+    const userIcon = IconRenderer && typeof IconRenderer === 'function' ? IconRenderer({ data: data, type: 'leaf' }) : null
+    const renderedIcon = userIcon ? (
+      <Icon size="large" currentTheme={currentTheme}>
+        {userIcon}
+      </Icon>
+    ) : (
+      <Icon size={theme._themes[currentTheme || 'dark'].textSize} defaultIcon currentTheme={currentTheme}>
+        <DefaultIcon />
+      </Icon>
+    )
 
     const content =
       typeof LeafRenderer === 'function' ? (
@@ -63,6 +64,7 @@ const LeafElement = React.forwardRef<HTMLDivElement, ElementProps>(
             selected={selected}
             currentTheme={currentTheme}
             onClick={(e) => handleClick(e, data.id)}
+            animateSelection={animateSelection}
           >
             <Wrapper level={level + 1}>
               {!noIcons && <span style={{ paddingRight: '8px' }}>{renderedIcon}</span>}

--- a/src/Tree/NodeElement.tsx
+++ b/src/Tree/NodeElement.tsx
@@ -1,16 +1,16 @@
+import { m } from 'framer-motion'
 import * as React from 'react'
 import styled, { useTheme } from 'styled-components'
-import { m } from 'framer-motion'
-import { Element } from './Elements'
-import Wrapper from './Wrapper'
-import { NodeText } from './Text'
-import { ElementProps, NodeId } from '../Tree'
-import Icon from './Icon'
 import Icons from '../assets/images/Icons'
+import { ElementProps, NodeId } from '../Tree'
+import { Element } from './Elements'
+import Icon from './Icon'
+import { NodeText } from './Text'
+import Wrapper from './Wrapper'
 
-const NodeContainer = styled(Element)<{ currentTheme: string; isOpen: boolean }>`
+const NodeContainer = styled(Element)<{ currentTheme: string; isOpen: boolean; animations?: boolean }>`
   border-left: ${({ isOpen, theme, currentTheme }) => (isOpen ? `4px solid ${theme._themes[currentTheme || 'dark'].indicator}` : '4px solid transparent')};
-  transition: all 0.2s linear;
+  ${({ animations }) => (animations ? 'transition: all 0.2s linear;' : '')}
 `
 
 const DefaultIcon = Icons['node']
@@ -30,7 +30,8 @@ const NodeElement = React.forwardRef<HTMLDivElement, ElementProps>(
       NodeRenderer = null,
       IconRenderer = null,
       borderTop = false,
-      selectable = true
+      selectable = true,
+      animateSelection = false
     },
     ref
   ) => {
@@ -52,12 +53,19 @@ const NodeElement = React.forwardRef<HTMLDivElement, ElementProps>(
     )
 
     const renderedIcon = React.useMemo(() => {
-      return IconRenderer && typeof IconRenderer === 'function' ? (
+      const userIcon = IconRenderer && typeof IconRenderer === 'function' ? IconRenderer({ data: data, type: 'node' }) : null
+      return userIcon ? (
         <Icon size="large" currentTheme={currentTheme}>
-          <IconRenderer data={data} type="node" />
+          {userIcon}
         </Icon>
       ) : (
-        <Icon size={theme._themes[currentTheme || 'dark'].textSize} currentTheme={currentTheme} defaultIcon animate={{ rotate: isOpen ? 90 : 0 }}>
+        <Icon
+          size={theme._themes[currentTheme || 'dark'].textSize}
+          currentTheme={currentTheme}
+          rotate={!animateSelection && isOpen ? 90 : undefined}
+          defaultIcon
+          animate={animateSelection ? { rotate: isOpen ? 90 : 0 } : undefined}
+        >
           <DefaultIcon />
         </Icon>
       )

--- a/src/assets/images/Icons.ts
+++ b/src/assets/images/Icons.ts
@@ -1,6 +1,6 @@
-import paperclip from './paperclip.svg'
-import circleNotch from './circle-notch.svg'
 import chevronRight from './chevron-right.svg'
+import circleNotch from './circle-notch.svg'
+import paperclip from './paperclip.svg'
 
 export default {
   file: paperclip,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,15 +1,15 @@
 /**
  * COMPONENTS AND LIBS
  */
+import { domAnimation, LazyMotion, m } from 'framer-motion'
 import * as React from 'react'
-import { LazyMotion, domAnimation, m } from 'framer-motion'
 import styled, { ThemeProvider } from 'styled-components'
-import Container from './Tree/Container'
-import coreTheme from './styles/theme'
-import Icon from './Tree/Icon'
 import Icons from './assets/images/Icons'
-export { NodeId, Leaf, LeafList, Node, NodeList, TreeProps, ToggleFunction, TreeRenderProps, ReactTreeTheme, ThemeSettings } from './Tree'
+import coreTheme from './styles/theme'
 import { NodeId, NodeList, TreeProps, TreeRenderProps } from './Tree'
+import Container from './Tree/Container'
+import Icon from './Tree/Icon'
+export { Leaf, LeafList, Node, NodeId, NodeList, ReactTreeTheme, ThemeSettings, ToggleFunction, TreeProps, TreeRenderProps } from './Tree'
 
 /**
  * Building blocks
@@ -105,7 +105,9 @@ const Tree: React.FC<
   emptyItemsString = null,
   toggleSelect = true,
   multiSelect = true,
-  unselectOnOutsideClick = true
+  unselectOnOutsideClick = true,
+  animateSelection = true,
+  animateDropdown = false || animations
 }) => {
   /**
    * We need to ensure that any changes to the content of the nodes list (create, delete)
@@ -260,7 +262,8 @@ const Tree: React.FC<
           NodeRenderer={NodeRenderer}
           LeafRenderer={LeafRenderer}
           IconRenderer={IconRenderer}
-          animations={animations}
+          animateDropdown={animateDropdown}
+          animateSelection={animateSelection}
           emptyItemsString={emptyItemsString}
         />
       )}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -43,7 +43,6 @@ const Message = styled(m.div)`
 
 const genericStateToggler = (
   stateSetter: React.Dispatch<React.SetStateAction<NodeId[]>>,
-  callback: (nodeIds: NodeId[]) => void,
   toggleAllowed: boolean,
   multiAllowed: boolean,
   nodeId: NodeId,
@@ -60,7 +59,6 @@ const genericStateToggler = (
       if (toggledIndex != -1) {
         result = []
       }
-      callback(result)
       return result
     }
 
@@ -70,7 +68,6 @@ const genericStateToggler = (
     } else {
       _p.push(nodeId)
     }
-    callback(_p)
     return _p
   })
 }
@@ -119,6 +116,14 @@ const Tree: React.FC<
   const [openNodeIds, setOpenNodeIds] = React.useState<NodeId[]>([])
   const treeRef = React.useRef<HTMLDivElement>(null)
 
+  React.useEffect(() => {
+    onSelect(selectedNodeIds)
+  }, [selectedNodeIds])
+
+  React.useEffect(() => {
+    onOpenClose(openNodeIds)
+  }, [openNodeIds])
+
   // listen to changes on nodes
   React.useEffect(() => {
     setInternalNodes(nodes)
@@ -149,7 +154,7 @@ const Tree: React.FC<
    */
 
   // 1. Handling a single select toggle
-  const toggleNodeSelection = genericStateToggler.bind(null, setSelectedNodeIds, onSelect, toggleSelect, multiSelect)
+  const toggleNodeSelection = genericStateToggler.bind(null, setSelectedNodeIds, toggleSelect, multiSelect)
 
   // 2. Handling a ALL select toggle
   const toggleSelectAllNodes = (): boolean => {
@@ -174,7 +179,7 @@ const Tree: React.FC<
   }
 
   // 3. Toggling an open node
-  const toggleOpenCloseNode = genericStateToggler.bind(null, setOpenNodeIds, onOpenClose, true, true)
+  const toggleOpenCloseNode = genericStateToggler.bind(null, setOpenNodeIds, true, true)
 
   // 4. Toggling all nodes open/closed
   const toggleOpenCloseAllNodes = (): boolean => {


### PR DESCRIPTION
1) Selection-change callbacks are now made outside of the setState hook. They were previously being called from within a setState Dispatch function, which (I think) meant that if the callback code modifies other app state, this causes a "cannot update a component while rendering another component" error. I had logged this as an issue earlier (https://github.com/naisutech/react-tree/issues/68), but my first proposed solution used useEffect hooks, whereas this PR'd code doesn't.

2) I was working on Windows for a bit this week, so added some Windows-specific yarn scripts.

3) IconRenderer function can now return null to use default icon behaviour. My own use case for this was that I liked the arrow for the Nodes, so only wanted to replace the Leaf icons.

4) The `animations` prop controlled the "cascading" animation of the dropdown lists, but not the animation of the rotating arrow or the fade-in of the leaf selection color. This was clashing with the non-animated lists etc on my app, so I created a prop called `animateSelection` to control these (default=true), and renamed the other one to `animateDropdown` (default=false) though the legacy `animations` prop should still work.